### PR TITLE
Implement the bgsave-cpu-mask option

### DIFF
--- a/src/rdb.c
+++ b/src/rdb.c
@@ -33,6 +33,7 @@
 #include "endianconv.h"
 
 #include <math.h>
+#include <sched.h>
 #include <sys/types.h>
 #include <sys/time.h>
 #include <sys/resource.h>
@@ -1080,6 +1081,9 @@ int rdbSaveBackground(char *filename, rdbSaveInfo *rsi) {
         /* Child */
         closeListeningSockets(0);
         redisSetProcTitle("redis-rdb-bgsave");
+        if (server.bgsave_cpu_set != NULL) {
+          sched_setaffinity(0, sizeof(cpu_set_t), server.bgsave_cpu_set);
+        }
         retval = rdbSave(filename,rsi);
         if (retval == C_OK) {
             size_t private_dirty = zmalloc_get_private_dirty(-1);

--- a/src/server.h
+++ b/src/server.h
@@ -35,6 +35,7 @@
 #include "solarisfixes.h"
 #include "rio.h"
 
+#include <sched.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1038,6 +1039,7 @@ struct redisServer {
     int rdb_bgsave_scheduled;       /* BGSAVE when possible if true. */
     int rdb_child_type;             /* Type of save by active child. */
     int lastbgsave_status;          /* C_OK or C_ERR */
+    cpu_set_t *bgsave_cpu_set;      /* CPU affinity for BGSAVE process */
     int stop_writes_on_bgsave_err;  /* Don't allow writes if can't BGSAVE */
     int rdb_pipe_write_result_to_parent; /* RDB pipes used to return the state */
     int rdb_pipe_read_result_from_child; /* of each slave in diskless SYNC. */


### PR DESCRIPTION
The bgsave-cpu-mask allows the user to provide a hex CPU set mask for setting the affinity of the forked bgsave process.

This is a very quick'n'dirty, Linux-only initial implementation (i.e., it won't even compile on other systems).